### PR TITLE
Make conda package python independant

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -10,11 +10,13 @@ source:
     git_url: ../
 
 build:
-    script: python setup.py install
+    noarch: python
+    script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed"
 
 requirements:
-    build:
+    host:
         - python
+        - pip
         - pbr
     run:
         - python


### PR DESCRIPTION
Use a single conda package for all python versions https://www.anaconda.com/condas-new-noarch-packages/